### PR TITLE
Screw it, make ftb ultimine not require a breakable item to work

### DIFF
--- a/config/ftbultimine.snbt
+++ b/config/ftbultimine.snbt
@@ -14,5 +14,5 @@
 	
 	# Require damageable tools or items added to ftbultimine:tools tag to ultimine.
 	# Default: false
-	require_tool: true
+	require_tool: false
 }


### PR DESCRIPTION
Title.

I know this is a controversial change, but requiring a tool seems to cause a lot of issues. If e6 had it like that, why change it in e8?

(Fixes #182 and maybe some other ones)