### PR TITLE
Change Drop rates for Sage and Hemp Seeds (#339)

### DIFF
--- a/kubejs/data/hexerei/loot_modifiers/sage_seeds_from_grass.json
+++ b/kubejs/data/hexerei/loot_modifiers/sage_seeds_from_grass.json
@@ -1,13 +1,17 @@
 {
-    "type": "immersiveengineering:hemp_seed_drops",
+    "type": "hexerei:sage_seeds_from_grass",
     "conditions": [
       {
         "condition": "minecraft:random_chance",
         "chance": 0.025
       },
       {
+        "condition": "minecraft:block_state_property",
+        "block": "minecraft:grass"
+      },
+      {
         "condition": "minecraft:inverted",
-        "term": {
+        "term":  {
           "condition": "minecraft:match_tool",
           "predicate": {
             "items": [
@@ -15,10 +19,7 @@
             ]
           }
         }
-      },
-      {
-        "condition": "block_state_property",
-        "block": "minecraft:tall_grass"
       }
-    ]
+    ],
+    "addition": "hexerei:sage_seed"
   }

--- a/kubejs/data/hexerei/loot_modifiers/sage_seeds_from_grass.json
+++ b/kubejs/data/hexerei/loot_modifiers/sage_seeds_from_grass.json
@@ -1,23 +1,23 @@
 {
-    "type": "hexerei:sage_seeds_from_grass",
-    "conditions": [
-      {
-        "condition": "minecraft:random_chance",
-        "chance": 0.025
-      },
-      {
-        "condition": "minecraft:block_state_property",
-        "block": "minecraft:grass"
-      },
-      {
-        "condition": "minecraft:inverted",
-        "term":  {
-          "condition": "minecraft:match_tool",
-          "predicate": {
-            "tag": "forge:shears"
-          }
+  "type": "hexerei:sage_seeds_from_grass",
+  "conditions": [
+    {
+      "condition": "minecraft:random_chance",
+      "chance": 0.025
+    },
+    {
+      "condition": "minecraft:block_state_property",
+      "block": "minecraft:grass"
+    },
+    {
+      "condition": "minecraft:inverted",
+      "term":  {
+        "condition": "minecraft:match_tool",
+        "predicate": {
+          "tag": "forge:shears"
         }
       }
-    ],
-    "addition": "hexerei:sage_seed"
-  }
+    }
+  ],
+  "addition": "hexerei:sage_seed"
+}

--- a/kubejs/data/hexerei/loot_modifiers/sage_seeds_from_grass.json
+++ b/kubejs/data/hexerei/loot_modifiers/sage_seeds_from_grass.json
@@ -14,9 +14,7 @@
         "term":  {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "items": [
-              "minecraft:shears"
-            ]
+            "tag": "forge:shears"
           }
         }
       }

--- a/kubejs/data/hexerei/loot_modifiers/sage_seeds_from_tall_grass.json
+++ b/kubejs/data/hexerei/loot_modifiers/sage_seeds_from_tall_grass.json
@@ -1,13 +1,17 @@
 {
-    "type": "immersiveengineering:hemp_seed_drops",
+    "type": "hexerei:sage_seeds_from_grass",
     "conditions": [
       {
         "condition": "minecraft:random_chance",
         "chance": 0.025
       },
       {
+        "condition": "minecraft:block_state_property",
+        "block": "minecraft:tall_grass"
+      },
+      {
         "condition": "minecraft:inverted",
-        "term": {
+        "term":  {
           "condition": "minecraft:match_tool",
           "predicate": {
             "items": [
@@ -15,10 +19,7 @@
             ]
           }
         }
-      },
-      {
-        "condition": "block_state_property",
-        "block": "minecraft:tall_grass"
       }
-    ]
+    ],
+    "addition": "hexerei:sage_seed"
   }

--- a/kubejs/data/hexerei/loot_modifiers/sage_seeds_from_tall_grass.json
+++ b/kubejs/data/hexerei/loot_modifiers/sage_seeds_from_tall_grass.json
@@ -14,9 +14,7 @@
         "term":  {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "items": [
-              "minecraft:shears"
-            ]
+            "tag": "forge:shears"
           }
         }
       }

--- a/kubejs/data/hexerei/loot_modifiers/sage_seeds_from_tall_grass.json
+++ b/kubejs/data/hexerei/loot_modifiers/sage_seeds_from_tall_grass.json
@@ -1,23 +1,23 @@
 {
-    "type": "hexerei:sage_seeds_from_grass",
-    "conditions": [
-      {
-        "condition": "minecraft:random_chance",
-        "chance": 0.025
-      },
-      {
-        "condition": "minecraft:block_state_property",
-        "block": "minecraft:tall_grass"
-      },
-      {
-        "condition": "minecraft:inverted",
-        "term":  {
-          "condition": "minecraft:match_tool",
-          "predicate": {
-            "tag": "forge:shears"
-          }
+  "type": "hexerei:sage_seeds_from_grass",
+  "conditions": [
+    {
+      "condition": "minecraft:random_chance",
+      "chance": 0.025
+    },
+    {
+      "condition": "minecraft:block_state_property",
+      "block": "minecraft:tall_grass"
+    },
+    {
+      "condition": "minecraft:inverted",
+      "term":  {
+        "condition": "minecraft:match_tool",
+        "predicate": {
+          "tag": "forge:shears"
         }
       }
-    ],
-    "addition": "hexerei:sage_seed"
-  }
+    }
+  ],
+  "addition": "hexerei:sage_seed"
+}

--- a/kubejs/data/immersiveengineering/loot_modifiers/hemp_from_grass.json
+++ b/kubejs/data/immersiveengineering/loot_modifiers/hemp_from_grass.json
@@ -1,1 +1,24 @@
-{"type":"immersiveengineering:hemp_seed_drops","conditions":[{"condition":"minecraft:random_chance","chance":0.01},{"condition":"minecraft:inverted","term":{"condition":"minecraft:match_tool","predicate":{"item":"minecraft:shears"}}},{"condition":"block_state_property","block":"minecraft:grass"}]}
+{
+    "type": "immersiveengineering:hemp_seed_drops",
+    "conditions": [
+      {
+        "condition": "minecraft:random_chance",
+        "chance": 0.025
+      },
+      {
+        "condition": "minecraft:inverted",
+        "term": {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "items": [
+              "minecraft:shears"
+            ]
+          }
+        }
+      },
+      {
+        "condition": "block_state_property",
+        "block": "minecraft:grass"
+      }
+    ]
+  }

--- a/kubejs/data/immersiveengineering/loot_modifiers/hemp_from_grass.json
+++ b/kubejs/data/immersiveengineering/loot_modifiers/hemp_from_grass.json
@@ -1,22 +1,22 @@
 {
-    "type": "immersiveengineering:hemp_seed_drops",
-    "conditions": [
-      {
-        "condition": "minecraft:random_chance",
-        "chance": 0.025
-      },
-      {
-        "condition": "minecraft:inverted",
-        "term": {
-          "condition": "minecraft:match_tool",
-          "predicate": {
-            "tag": "forge:shears"
-          }
+  "type": "immersiveengineering:hemp_seed_drops",
+  "conditions": [
+    {
+      "condition": "minecraft:random_chance",
+      "chance": 0.025
+    },
+    {
+      "condition": "minecraft:inverted",
+      "term": {
+        "condition": "minecraft:match_tool",
+        "predicate": {
+          "tag": "forge:shears"
         }
-      },
-      {
-        "condition": "block_state_property",
-        "block": "minecraft:grass"
       }
-    ]
-  }
+    },
+    {
+      "condition": "block_state_property",
+      "block": "minecraft:grass"
+    }
+  ]
+}

--- a/kubejs/data/immersiveengineering/loot_modifiers/hemp_from_tall_grass.json
+++ b/kubejs/data/immersiveengineering/loot_modifiers/hemp_from_tall_grass.json
@@ -10,9 +10,7 @@
         "term": {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "items": [
-              "minecraft:shears"
-            ]
+            "tag": "forge:shears"
           }
         }
       },

--- a/kubejs/data/immersiveengineering/loot_modifiers/hemp_from_tall_grass.json
+++ b/kubejs/data/immersiveengineering/loot_modifiers/hemp_from_tall_grass.json
@@ -1,22 +1,22 @@
 {
-    "type": "immersiveengineering:hemp_seed_drops",
-    "conditions": [
-      {
-        "condition": "minecraft:random_chance",
-        "chance": 0.025
-      },
-      {
-        "condition": "minecraft:inverted",
-        "term": {
-          "condition": "minecraft:match_tool",
-          "predicate": {
-            "tag": "forge:shears"
-          }
+  "type": "immersiveengineering:hemp_seed_drops",
+  "conditions": [
+    {
+      "condition": "minecraft:random_chance",
+      "chance": 0.025
+    },
+    {
+      "condition": "minecraft:inverted",
+      "term": {
+        "condition": "minecraft:match_tool",
+        "predicate": {
+          "tag": "forge:shears"
         }
-      },
-      {
-        "condition": "block_state_property",
-        "block": "minecraft:tall_grass"
       }
-    ]
-  }
+    },
+    {
+      "condition": "block_state_property",
+      "block": "minecraft:tall_grass"
+    }
+  ]
+}

--- a/kubejs/data/occultism/loot_modifiers/datura_seed_from_grass.json
+++ b/kubejs/data/occultism/loot_modifiers/datura_seed_from_grass.json
@@ -1,9 +1,13 @@
 {
-    "type": "immersiveengineering:hemp_seed_drops",
+    "type": "occultism:add_item",
     "conditions": [
       {
         "condition": "minecraft:random_chance",
-        "chance": 0.025
+        "chance": 0.02
+      },
+      {
+        "condition": "minecraft:block_state_property",
+        "block": "minecraft:grass"
       },
       {
         "condition": "minecraft:inverted",
@@ -13,10 +17,8 @@
             "tag": "forge:shears"
           }
         }
-      },
-      {
-        "condition": "block_state_property",
-        "block": "minecraft:grass"
       }
-    ]
+    ],
+    "item": "occultism:datura_seeds",
+    "count": 1
   }

--- a/kubejs/data/occultism/loot_modifiers/datura_seed_from_tall_grass.json
+++ b/kubejs/data/occultism/loot_modifiers/datura_seed_from_tall_grass.json
@@ -1,9 +1,13 @@
 {
-    "type": "immersiveengineering:hemp_seed_drops",
+    "type": "occultism:add_item",
     "conditions": [
       {
         "condition": "minecraft:random_chance",
-        "chance": 0.025
+        "chance": 0.02
+      },
+      {
+        "condition": "block_state_property",
+        "block": "minecraft:tall_grass"
       },
       {
         "condition": "minecraft:inverted",
@@ -13,10 +17,8 @@
             "tag": "forge:shears"
           }
         }
-      },
-      {
-        "condition": "block_state_property",
-        "block": "minecraft:grass"
       }
-    ]
+    ],
+    "item": "occultism:datura_seeds",
+    "count": 1
   }


### PR DESCRIPTION
Fixes Hemp Seed drop rate override
Bumped up the rate from 0.01 to 0.025
Lowered the rate for Sage seeds from 0.1 to 0.025

This PR Resolves:
#339 